### PR TITLE
feat: make /etc writable in order to set a root password... and more

### DIFF
--- a/build/sd_payload/wifi/config.sh
+++ b/build/sd_payload/wifi/config.sh
@@ -35,6 +35,8 @@ do
 done
 # You probably want to change this file content with your own resolvers
 cp -f /var/nm/resolv.conf /etc/
+# Now copy our own etc/ data
+cp -rf ${fetc}/own/* ${fetc}/
 
 # Fork our script to run in the background
 /var/tmp/sd/wifi/fork_process.sh 2>&1 &


### PR DESCRIPTION
In the camera, `/etc` is read only and `telnet` access leaves the `root` user passwordless, which is a massive security risk.
This patch uses the `mount --bind` capability available in `busybox` in order to overlay a /etc directory from the sdcard to the root filesystem.